### PR TITLE
chore: Add 4 new companies and 150+ new interview questions from 2026 research

### DIFF
--- a/FAANG-Recent-Questions.md
+++ b/FAANG-Recent-Questions.md
@@ -59,13 +59,25 @@
   - [Binary Search and Algorithms](#databricks-binary-search--algorithms)
   - [System Design](#databricks-system-design)
   - [Concurrency](#databricks-concurrency)
+- [Stripe](#stripe)
+  - [Coding and Integration](#stripe-coding-and-integration)
+  - [Bug Squash and API Design](#stripe-bug-squash-and-api-design)
+- [NVIDIA](#nvidia)
+  - [Algorithms](#nvidia-algorithms)
+  - [GPU and Systems](#nvidia-gpu-and-systems)
+- [Uber](#uber)
+  - [Algorithms](#uber-algorithms)
+  - [System Design](#uber-system-design)
+- [ByteDance / TikTok](#bytedance--tiktok)
+  - [Algorithms](#bytedance-algorithms)
+  - [System Design](#bytedance-system-design)
 - [Topic-wise Questions](#topic-wise-questions)
 
 ---
 
 ## Meta (formerly Facebook)
 
-> **2025-2026 Trends**: De-emphasis of DP, rise of expression parsing/stack problems, streaming and sparse data, speed and clean code prioritized over brute force. ~26% Easy, 60% Medium, 14% Hard.
+> **2025-2026 Trends**: De-emphasis of DP, rise of expression parsing/stack problems, streaming and sparse data, speed and clean code prioritized over brute force. ~26% Easy, 60% Medium, 14% Hard. **New in 2026**: AI-Enabled Coding Round (replaces one onsite round) uses CoderPad with AI assistant (Claude, GPT, Gemini, Llama available). CodeSignal OA (90 min) with 4-stage progressive problems. Two problems in 35 minutes for traditional rounds -- speed is king.
 
 ### Meta Arrays and Strings
 
@@ -83,6 +95,11 @@
 | 10 | [Continuous Subarray Sum](https://leetcode.com/problems/continuous-subarray-sum) | Medium |
 | 11 | [Add Strings](https://leetcode.com/problems/add-strings) | Easy |
 | 12 | [Maximum Swap](https://leetcode.com/problems/maximum-swap) | Medium |
+| 13 | [Valid Word Abbreviation](https://leetcode.com/problems/valid-word-abbreviation) | Easy |
+| 14 | [Merge Strings Alternately](https://leetcode.com/problems/merge-strings-alternately) | Easy |
+| 15 | [Diagonal Traverse](https://leetcode.com/problems/diagonal-traverse) | Medium |
+| 16 | [Next Permutation](https://leetcode.com/problems/next-permutation) | Medium |
+| 17 | [Interval List Intersections](https://leetcode.com/problems/interval-list-intersections) | Medium |
 
 ### Meta Linked Lists
 
@@ -108,6 +125,10 @@
 | 8 | [Shortest Path in Binary Matrix](https://leetcode.com/problems/shortest-path-in-binary-matrix) | Medium |
 | 9 | [Making a Large Island](https://leetcode.com/problems/making-a-large-island) | Hard |
 | 10 | [Range Sum of BST](https://leetcode.com/problems/range-sum-of-bst) | Easy |
+| 11 | [Lowest Common Ancestor of a Binary Tree III](https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-tree-iii) | Medium |
+| 12 | [All Nodes Distance K in Binary Tree](https://leetcode.com/problems/all-nodes-distance-k-in-binary-tree) | Medium |
+| 13 | [Convert BST to Sorted Doubly Linked List](https://leetcode.com/problems/convert-binary-search-tree-to-sorted-doubly-linked-list) | Medium |
+| 14 | [K Closest Points to Origin](https://leetcode.com/problems/k-closest-points-to-origin) | Medium |
 
 ### Meta Recursion and Backtracking
 
@@ -304,7 +325,7 @@
 
 ## Google
 
-> **2025-2026 Trends**: Graphs appear in 76% of onsite loops at L4+. Sliding window and binary search on answer are top-tier patterns. Trie and Union-Find questions rising. Medium-difficulty dominance (52% Medium). Follow-up questions are standard.
+> **2025-2026 Trends**: Graphs appear in 76% of onsite loops at L4+. Sliding window and binary search on answer are top-tier patterns. Trie and Union-Find questions rising. Medium-difficulty dominance (52% Medium). Follow-up questions are standard. **New in 2026**: Piloting "Code Comprehension" round where candidates analyze multi-file codebases with Gemini AI available. Google Hiring Assessment (GHA) now mandatory before recruiter contact. In-person interviews returning due to AI cheating concerns.
 
 ### Google Arrays and Strings
 
@@ -416,7 +437,7 @@
 
 ## LinkedIn
 
-> **2025-2026 Trends**: AI-enabled coding round using CoderPad + AI assistant. Production-oriented follow-ups (concurrency, multithreading). Strong emphasis on custom data structure design. BFS emphasis reflecting graph-based social network domain.
+> **2025-2026 Trends**: AI-enabled coding round using CoderPad + AI assistant (Claude/Opus available). Production-oriented follow-ups (concurrency, multithreading). Strong emphasis on custom data structure design. BFS emphasis reflecting graph-based social network domain. **New in 2026**: AI-Enabled round replaces one traditional coding round. The coding problem itself is standard, but follow-ups push into concurrency, multithreading, and productionization -- that's where candidates struggle. 5 onsite rounds total.
 
 ### LinkedIn Data Structure Design
 
@@ -456,7 +477,7 @@
 
 ## OpenAI
 
-> **2025-2026 Trends**: Production over puzzles. Problems drawn from a fixed bank of ~8 core challenges with progressive difficulty layers. Python strongly recommended. Coding bar is non-negotiable. Mission alignment evaluated.
+> **2025-2026 Trends**: Production over puzzles. Problems drawn from a fixed bank of ~8 core challenges with progressive difficulty layers. Python strongly recommended. Coding bar is non-negotiable. Mission alignment evaluated. **New in 2026**: 48-hour take-home project (most common: distributed webhook delivery system with retry logic). Technical screen uses progressive "gate" format: single problem gets harder across 4 stages, must pass at least 2 to advance. Average time to hire: 26 days for SWE.
 
 ### OpenAI Core Custom Problems
 
@@ -471,6 +492,10 @@ These are unique to OpenAI and not standard LeetCode problems.
 | 5 | Resumable Iterator | Hard | Iterator / State | Stateful iterator with `getState()`/`setState()`, nested structures, async |
 | 6 | Async Node Counting | Hard | Distributed / Trees | Count tree nodes using only async parent-child messaging |
 | 7 | Toy Language Interpreter | Hard | Parsing / Compilers | 75-min round: lexer, parser, evaluator for variables, arithmetic, control flow |
+| 8 | GPU Credit Allocation / Manager | Hard | Design / State | Add credits with expiration, auto-expire, deduct with history tracking |
+| 9 | Rate Limiter with Sliding Window | Hard | Design / Algorithms | Sliding window or token bucket implementation |
+| 10 | SQL Engine / Parser + Executor | Hard | Parsing / Design | Build parser + executor for basic SQL operations |
+| 11 | Versioned KV Store | Hard | Design / Binary Search | Put with auto-versioning, get by version with history |
 
 ### OpenAI LeetCode-Equivalent Problems
 
@@ -515,7 +540,7 @@ These are unique to OpenAI and not standard LeetCode problems.
 
 ## Anthropic
 
-> **2025-2026 Trends**: CodeSignal OA (60-90 min) then 4-6 hour onsite with 4-6 rounds. Python expected. AI tools strictly prohibited. Custom problems drawn from a bank of ~6 core challenges with progressive difficulty layers. Concurrency/async round is common. Strong AI safety and alignment focus.
+> **2025-2026 Trends**: CodeSignal OA (90 min, score 520+ to advance) then 4-6 hour onsite with 4-6 rounds. Python expected. AI tools strictly prohibited -- Anthropic uses LLMs to detect code engineered to pass tests without genuinely solving the problem. **New in 2026**: Values/Culture round (45 min) is universal and the #1 failure point -- NOT behavioral/STAR; probes ethical judgment and AI safety reasoning. "Measured doubt" about mission scores better than performed enthusiasm. New system design topics include inference batching and batch inferencing API for LLM queries.
 
 ### Anthropic Core Custom Coding Problems
 
@@ -529,6 +554,10 @@ These are Anthropic's own custom problems — not LeetCode. Each has multiple di
 | 4 | Stack Trace / Profiler | Hard | Parsing / Design | Convert sampling profiler data to chronological events |
 | 5 | Tokenization Engine | Hard | String / NLP | Code review, tokenize/detokenize with vocabulary coverage |
 | 6 | Distributed Mode/Median | Hard | Distributed Systems | Compute statistics across 10 nodes with bandwidth constraints |
+| 7 | Bank System / Bank Account | Hard | Design / Refactoring | Progressive: account creation -> merging -> cashback logic requiring redesign |
+| 8 | File System Implementation | Hard | Design | Layered stages of increasing complexity |
+| 9 | Package Manager | Hard | Graph / Design | Toy package manager with dependency resolution |
+| 10 | Duplicate File Finder | Hard | Hashing / File System | File dedup via hashing; related to LC 609 |
 
 ### Anthropic LeetCode Practice (Mapped to Focus Areas)
 
@@ -704,6 +733,166 @@ Domain-specific: interrupt-safe circular buffers in C, CAN bus protocol design, 
 | 5 | [Fizz Buzz Multithreaded](https://leetcode.com/problems/fizz-buzz-multithreaded) | Medium |
 
 Custom concurrency problems also reported: thread-safe logger with disk flush, rate limiter with mutexes, producer-consumer with condition variables.
+
+---
+
+## Stripe
+
+> **2025-2026 Trends**: Stripe does NOT use traditional LeetCode-style interviews. Problems model real engineering work -- payment processing, debugging, API integration. Process spans 7-9 weeks. Unique rounds: Bug Squash (debug a GitHub repo with real issues), Integration (build with Stripe API), API Design (REST resource modeling, idempotency, versioning). Production code quality valued over algorithmic cleverness -- O(n^2) is fine if code is clean. Speed is NOT measured.
+
+### Stripe Coding and Integration
+
+| No. | Question | Difficulty |
+| --- | -------- | ---------- |
+| 1 | [Two Sum](https://leetcode.com/problems/two-sum) | Easy |
+| 2 | [LRU Cache](https://leetcode.com/problems/lru-cache) | Medium |
+| 3 | [Merge Intervals](https://leetcode.com/problems/merge-intervals) | Medium |
+| 4 | [Design Hit Counter](https://leetcode.com/problems/design-hit-counter) | Medium |
+| 5 | [Top K Frequent Elements](https://leetcode.com/problems/top-k-frequent-elements) | Medium |
+| 6 | [Subarray Sum Equals K](https://leetcode.com/problems/subarray-sum-equals-k) | Medium |
+| 7 | [Time Based Key-Value Store](https://leetcode.com/problems/time-based-key-value-store) | Medium |
+| 8 | [Course Schedule](https://leetcode.com/problems/course-schedule) | Medium |
+| 9 | [Coin Change](https://leetcode.com/problems/coin-change) | Medium |
+| 10 | [Serialize and Deserialize Binary Tree](https://leetcode.com/problems/serialize-and-deserialize-binary-tree) | Hard |
+| 11 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum) | Hard |
+
+### Stripe Bug Squash and API Design
+
+**Custom Problems (unique to Stripe)**
+
+| No. | Problem | Category | Description |
+| --- | ------- | -------- | ----------- |
+| 1 | Invoice Reconciliation | Data Processing | Parse CSV of transactions, filter by status, output totals per user |
+| 2 | Request Deduplication | Integration | Build idempotent request handler preventing duplicate charges |
+| 3 | Webhook Handler Debug | Bug Squash | Find and fix bugs in a failing webhook handler with unit tests |
+| 4 | API Response Parser | Bug Squash | Debug parser that silently drops fields |
+| 5 | Payment Retry Logic | Integration | Implement retry logic with exponential backoff |
+| 6 | Shipping Cost Calculator | Multi-part | Progressive complexity layers on cost calculation |
+
+**System Design**: Payment processing pipelines, fraud detection, idempotent distributed ledgers, multi-currency payment routing, webhook retry systems. Domain knowledge expected: PCI compliance, idempotency patterns, double-entry bookkeeping.
+
+---
+
+## NVIDIA
+
+> **2025-2026 Trends**: Most strategically central tech company in 2026 due to AI infrastructure dominance. Emphasizes performance awareness over generalist coding. After solving baseline, expect follow-ups: "How does this behave under memory pressure? What's the cache miss profile? How would you parallelize across 10,000 threads?" C++ essential for systems/GPU roles; Python acceptable for ML/infra. Difficulty: 8 Easy, 29 Medium, 9 Hard across 46 tracked problems.
+
+### NVIDIA Algorithms
+
+| No. | Question | Difficulty |
+| --- | -------- | ---------- |
+| 1 | [Maximum Number of Events That Can Be Attended](https://leetcode.com/problems/maximum-number-of-events-that-can-be-attended) | Medium |
+| 2 | [Min Stack](https://leetcode.com/problems/min-stack) | Medium |
+| 3 | [Clone Graph](https://leetcode.com/problems/clone-graph) | Medium |
+| 4 | [K Closest Points to Origin](https://leetcode.com/problems/k-closest-points-to-origin) | Medium |
+| 5 | [Random Pick with Weight](https://leetcode.com/problems/random-pick-with-weight) | Medium |
+| 6 | [Trapping Rain Water](https://leetcode.com/problems/trapping-rain-water) | Hard |
+| 7 | [Number of Islands](https://leetcode.com/problems/number-of-islands) | Medium |
+| 8 | [Rotate Image](https://leetcode.com/problems/rotate-image) | Medium |
+| 9 | [Word Break](https://leetcode.com/problems/word-break) | Medium |
+| 10 | [Shortest Path in Binary Matrix](https://leetcode.com/problems/shortest-path-in-binary-matrix) | Medium |
+| 11 | [Longest Increasing Path in a Matrix](https://leetcode.com/problems/longest-increasing-path-in-a-matrix) | Hard |
+| 12 | [Expression Add Operators](https://leetcode.com/problems/expression-add-operators) | Hard |
+| 13 | [Word Ladder II](https://leetcode.com/problems/word-ladder-ii) | Hard |
+| 14 | [Bus Routes](https://leetcode.com/problems/bus-routes) | Hard |
+| 15 | [Making A Large Island](https://leetcode.com/problems/making-a-large-island) | Hard |
+
+### NVIDIA GPU and Systems
+
+**CUDA/GPU-Specific Problems**
+
+| No. | Problem | Category | Description |
+| --- | ------- | -------- | ----------- |
+| 1 | CUDA Memory Optimization | GPU Programming | Optimize matrix operations for GPU memory hierarchy |
+| 2 | CUDA Kernel Fusion | Performance | Fuse Transformer attention operations into efficient kernels |
+| 3 | Matrix Multiplication Optimization | Parallel Computing | Implement GEMM considering cache locality and thread scheduling |
+| 4 | Sorting Algorithm Parallelization | GPU Computing | Implement parallel sort analyzing stability and parallelizability |
+| 5 | Memory Coalescing Analysis | CUDA | Fix uncoalesced memory access patterns in warp execution |
+| 6 | Thread Synchronization | Concurrency | Implement barrier synchronization across thread blocks |
+| 7 | Multi-GPU Communication | Distributed | Optimize communication patterns in distributed training |
+
+**Key topics**: GPU memory architecture (SRAM vs HBM), CUDA thread hierarchy (threads/warps/blocks/grids), KV-cache optimization, LoRA fine-tuning, Mixture-of-Experts, beam search
+
+---
+
+## Uber
+
+> **2025-2026 Trends**: Interviews reflect product domain -- routing, dispatch, surge pricing map to graph traversal, streaming aggregation, sliding-window patterns. OA: 4 problems in 70-90 minutes on CodeSignal. Code readability explicitly evaluated. L5A (Senior): 5 rounds total with elimination Round 0 (LeetCode Medium). Difficulty: 7% Easy, 73% Medium, 20% Hard.
+
+### Uber Algorithms
+
+| No. | Question | Difficulty |
+| --- | -------- | ---------- |
+| 1 | [Maximize Amount After Two Days of Conversions](https://leetcode.com/problems/maximize-amount-after-two-days-of-conversions) | Medium |
+| 2 | [Bus Routes](https://leetcode.com/problems/bus-routes) | Hard |
+| 3 | [Alien Dictionary](https://leetcode.com/problems/alien-dictionary) | Hard |
+| 4 | [Number of Islands II](https://leetcode.com/problems/number-of-islands-ii) | Hard |
+| 5 | [Design Hit Counter](https://leetcode.com/problems/design-hit-counter) | Medium |
+| 6 | [Number of Islands](https://leetcode.com/problems/number-of-islands) | Medium |
+| 7 | [Spiral Matrix](https://leetcode.com/problems/spiral-matrix) | Medium |
+| 8 | [Word Search](https://leetcode.com/problems/word-search) | Medium |
+| 9 | [LRU Cache](https://leetcode.com/problems/lru-cache) | Medium |
+| 10 | [Evaluate Division](https://leetcode.com/problems/evaluate-division) | Medium |
+| 11 | [Random Pick with Weight](https://leetcode.com/problems/random-pick-with-weight) | Medium |
+| 12 | [Find Median from Data Stream](https://leetcode.com/problems/find-median-from-data-stream) | Hard |
+| 13 | [Merge Intervals](https://leetcode.com/problems/merge-intervals) | Medium |
+| 14 | [Meeting Rooms II](https://leetcode.com/problems/meeting-rooms-ii) | Medium |
+| 15 | [Longest Subarray With Absolute Diff <= Limit](https://leetcode.com/problems/longest-continuous-subarray-with-absolute-diff-less-than-or-equal-to-limit) | Medium |
+
+Custom problems: Expiry counter (TTL-based driver sessions), driver-rider matching engine, surge pricing calculator, adaptive bitrate selector.
+
+### Uber System Design
+
+| No. | Question | Key Focus |
+| --- | -------- | --------- |
+| 1 | Design a Ride-Hailing System | Distributed concurrency, real-time updates, consistency |
+| 2 | Design Real-Time Surge Pricing Engine | Millions of GPS pings/sec, supply vs demand, 30-second multiplier |
+| 3 | Design Location Tracking System | Millions of location updates/sec for drivers and riders |
+| 4 | Design Notification System at Scale | Push notifications, SMS, emails for ride updates |
+| 5 | Design ETA Prediction Service | ML-based arrival time estimation |
+
+---
+
+## ByteDance / TikTok
+
+> **2025-2026 Trends**: Among the most technically demanding interviews. Baseline is Medium, Hard is frequent. 2-3 problems per round (vs 1-2 at Google/Meta) -- speed matters. Interviewers progressively modify problems to increase difficulty in real-time. Compile-ready, bug-free code expected (not pseudocode). OA: 4 problems on CodeSignal, 70-min. Acceptance rate estimated at 1-2%. Max 2 applications allowed.
+
+### ByteDance Algorithms
+
+| No. | Question | Difficulty |
+| --- | -------- | ---------- |
+| 1 | [Implement Queue using Stacks](https://leetcode.com/problems/implement-queue-using-stacks) | Easy |
+| 2 | [Daily Temperatures](https://leetcode.com/problems/daily-temperatures) | Medium |
+| 3 | [Merge k Sorted Lists](https://leetcode.com/problems/merge-k-sorted-lists) | Hard |
+| 4 | [LRU Cache](https://leetcode.com/problems/lru-cache) | Medium |
+| 5 | [Max Consecutive Ones III](https://leetcode.com/problems/max-consecutive-ones-iii) | Medium |
+| 6 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum) | Hard |
+| 7 | [Number of Islands](https://leetcode.com/problems/number-of-islands) | Medium |
+| 8 | [Binary Tree Maximum Path Sum](https://leetcode.com/problems/binary-tree-maximum-path-sum) | Hard |
+| 9 | [Trapping Rain Water](https://leetcode.com/problems/trapping-rain-water) | Hard |
+| 10 | [3Sum](https://leetcode.com/problems/3sum) | Medium |
+| 11 | [Longest Valid Parentheses](https://leetcode.com/problems/longest-valid-parentheses) | Hard |
+| 12 | [N-Queens](https://leetcode.com/problems/n-queens) | Hard |
+| 13 | [Serialize and Deserialize Binary Tree](https://leetcode.com/problems/serialize-and-deserialize-binary-tree) | Hard |
+| 14 | [Coin Change](https://leetcode.com/problems/coin-change) | Medium |
+| 15 | [Regular Expression Matching](https://leetcode.com/problems/regular-expression-matching) | Hard |
+| 16 | [Longest Increasing Path in a Matrix](https://leetcode.com/problems/longest-increasing-path-in-a-matrix) | Hard |
+| 17 | [Minimum Difference in Sums After Removal of Elements](https://leetcode.com/problems/minimum-difference-in-sums-after-removal-of-elements) | Hard |
+| 18 | [Search in Rotated Sorted Array](https://leetcode.com/problems/search-in-rotated-sorted-array) | Medium |
+| 19 | [Kth Largest Element in an Array](https://leetcode.com/problems/kth-largest-element-in-an-array) | Medium |
+| 20 | [Course Schedule II](https://leetcode.com/problems/course-schedule-ii) | Medium |
+
+Custom problems: Video chunk scheduler, hashtag trend detector (sliding window on streams), comment tree flattening, content moderation priority queue, video deduplication via hashing, live viewer count at billion scale.
+
+### ByteDance System Design
+
+| No. | Question | Key Focus |
+| --- | -------- | --------- |
+| 1 | Design TikTok "For You" Page | Two-phase recommendation: candidate generation + ranking |
+| 2 | Design Real-Time Live Streaming System | Billion-scale concurrent users |
+| 3 | Design Content Moderation Pipeline | ML-based automated moderation at scale |
+| 4 | Design Social Graph Service | Following/follower relationships, efficient traversal |
+| 5 | Design Ad Serving Platform | Real-time bidding and targeting |
 
 ---
 

--- a/ML_INTERVIEW_PREP.md
+++ b/ML_INTERVIEW_PREP.md
@@ -410,6 +410,24 @@ Below are actual ML interview questions recently asked at top tech companies, or
 14. **How would you implement and evaluate a multi-agent system using LLMs for complex reasoning tasks?** (Microsoft, 2025)
 15. **Compare and contrast different techniques for efficient inference in LLMs (e.g., quantization, KV caching, speculative decoding).** (OpenAI, 2025)
 
+### LLM and AI Engineering Questions (2026 Updates)
+
+1. **How does DPO (Direct Preference Optimization) simplify RLHF? When would you choose DPO over PPO?** (Anthropic, OpenAI, 2026)
+2. **What is KV cache and how does it help in LLM inference? How would you optimize KV cache reuse?** (OpenAI, Google, 2026)
+3. **When do you route to a small distilled model vs. a large LLM? Design a model tiering/routing system.** (Google, Meta, 2026)
+4. **What is prompt compression and how does it reduce cost?** (OpenAI, 2026)
+5. **Explain multi-layer caching for GenAI: retrieval cache, prompt cache, response cache.** (Anthropic, Google, 2026)
+6. **Naive RAG fails at retrieval ~40% of the time. Explain Adaptive RAG, Corrective RAG (CRAG), Self-RAG, and Cache-Augmented Generation (CAG).** (All AI companies, 2026)
+7. **Explain semantic chunking vs fixed-size chunking for RAG pipelines. How do you detect topic boundaries?** (OpenAI, 2026)
+8. **How do you protect against prompt injection and jailbreaking in production LLM systems?** (Anthropic, OpenAI, 2026)
+9. **Your app gets 1M queries/day -- how do you optimize LLM cost? Cover token reduction, model tiering, prompt compression, and caching.** (All, 2026)
+10. **How do you handle PII in prompts and logs? Describe HIPAA-specific scenarios for healthcare GenAI.** (Google, Microsoft, 2026)
+11. **"Is there an actual eval framework, or is it vibes-based?" Build golden datasets, automated eval pipelines, and distinguish subjective quality from measurable metrics.** (OpenAI, 2026)
+12. **Implement LoRA and QLoRA from scratch. Explain when to use each.** (NVIDIA, Meta, 2026)
+13. **Design an autonomous agent architecture: orchestrator, tool gateway, memory systems, policy engine, state management, observability.** (Anthropic, OpenAI, Google, 2026)
+14. **What is speculative decoding and how does it improve inference throughput?** (Google, Anthropic, 2026)
+15. **Implement beam search, top-k, and top-p decoding algorithms.** (OpenAI, NVIDIA, 2026)
+
 ### MLOps Questions (2025 Updates)
 
 1. **How would you monitor an ML model in production? What metrics would you track?** (Google, 2023)
@@ -427,6 +445,16 @@ Below are actual ML interview questions recently asked at top tech companies, or
 13. **How would you implement an efficient continuous training pipeline for a model that needs to be updated daily?** (Amazon, 2025)
 14. **Explain your strategy for implementing model governance in an organization with multiple ML teams.** (Microsoft, 2025)
 15. **How would you design an ML infrastructure that can support both experimentation and production needs efficiently?** (OpenAI, 2025)
+
+### New Interview Formats (2026)
+
+Major companies are transforming their ML interview process in 2026:
+
+1. **AI-Paired Coding Rounds**: Google, Meta, and LinkedIn now include rounds where AI tools (Copilot, Claude, Gemini) are available. Candidates are scored on AI fluency, prompt engineering, output validation, and debugging AI-generated code.
+2. **Reasoning Labs**: Ambiguous ML challenges with no single correct answer. Evaluates thinking clarity, uncertainty handling, and ethical awareness.
+3. **AI Reasoning Challenge**: Candidates analyze AI-generated outputs (explanations, logs, summaries) and identify flaws, suggest improvements, and design verification experiments.
+4. **Ethics and Safety Rounds**: Now standalone at many companies. Sample: "detecting gender bias in LLMs" or "balancing accuracy with safety in dialogue models."
+5. **Dedicated MLOps Block**: A 45-minute MLOps interview testing data drift monitoring, pipeline debugging, and production reliability is now standard.
 
 ### Advanced ML & AI Topics (2025 Updates)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-  <p><strong>A curated collection of coding, system design, and ML interview questions from top tech companies.</strong><br/>Continuously updated with 2025-2026 interview questions.</p>
+  <p><strong>A curated collection of coding, system design, and ML interview questions from top tech companies.</strong><br/>Continuously updated with 2025-2026 interview questions across 17+ companies.</p>
 
   <a href="https://github.com/ombharatiya/FAANG-Coding-Interview-Questions/stargazers">
     <img src="https://img.shields.io/github/stars/ombharatiya/FAANG-Coding-Interview-Questions?style=flat" alt="GitHub stars" />
@@ -59,7 +59,11 @@
 | 10. | [Anthropic](#anthropic) |
 | 11. | [Palantir](#palantir) |
 | 12. | [Databricks](#databricks) |
-| 13. | [Flipkart](#flipkart) |
+| 13. | [Stripe](#stripe) |
+| 14. | [NVIDIA](#nvidia) |
+| 15. | [Uber](#uber) |
+| 16. | [ByteDance / TikTok](#bytedance--tiktok) |
+| 17. | [Flipkart](#flipkart) |
 
 ## Quick Start Guide
 
@@ -121,7 +125,7 @@
 ## Google
 
 <details>
-<summary>View 25 Problems (2025-2026 Most Frequent)</summary>
+<summary>View 35 Problems (2025-2026 Most Frequent)</summary>
 
 | No. | Problem | Difficulty | Category |
 | --- | ------- | ---------- | -------- |
@@ -150,13 +154,23 @@
 | 23 | [Minimum Window Substring](https://leetcode.com/problems/minimum-window-substring) | Hard | Sliding Window |
 | 24 | [Implement Trie (Prefix Tree)](https://leetcode.com/problems/implement-trie-prefix-tree) | Medium | Trie |
 | 25 | [Accounts Merge](https://leetcode.com/problems/accounts-merge) | Medium | Union-Find |
+| 26 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum) | Hard | Monotonic Deque |
+| 27 | [The Skyline Problem](https://leetcode.com/problems/the-skyline-problem) | Hard | Heap / Divide and Conquer |
+| 28 | [Largest Rectangle in Histogram](https://leetcode.com/problems/largest-rectangle-in-histogram) | Hard | Monotonic Stack |
+| 29 | [Word Search II](https://leetcode.com/problems/word-search-ii) | Hard | Trie / Backtracking |
+| 30 | [Rotting Oranges](https://leetcode.com/problems/rotting-oranges) | Medium | Graph / BFS |
+| 31 | [Critical Connections in a Network](https://leetcode.com/problems/critical-connections-in-a-network) | Hard | Graph / Tarjan's |
+| 32 | [Pacific Atlantic Water Flow](https://leetcode.com/problems/pacific-atlantic-water-flow) | Medium | Graph / Multi-source BFS |
+| 33 | [Network Delay Time](https://leetcode.com/problems/network-delay-time) | Medium | Graph / Dijkstra |
+| 34 | [Daily Temperatures](https://leetcode.com/problems/daily-temperatures) | Medium | Monotonic Stack |
+| 35 | [Find the Safest Path in a Grid](https://leetcode.com/problems/find-the-safest-path-in-a-grid) | Medium | BFS / Binary Search |
 
 </details>
 
 ## Meta (Facebook)
 
 <details>
-<summary>View 25 Problems (2025-2026 Most Frequent)</summary>
+<summary>View 35 Problems (2025-2026 Most Frequent)</summary>
 
 | No. | Problem | Difficulty | Category |
 | --- | ------- | ---------- | -------- |
@@ -185,13 +199,23 @@
 | 23 | [Copy List with Random Pointer](https://leetcode.com/problems/copy-list-with-random-pointer) | Medium | Linked List / Hash Table |
 | 24 | [Making a Large Island](https://leetcode.com/problems/making-a-large-island) | Hard | Graph / DFS / Union-Find |
 | 25 | [Expression Add Operators](https://leetcode.com/problems/expression-add-operators) | Hard | Backtracking / Math |
+| 26 | [Valid Word Abbreviation](https://leetcode.com/problems/valid-word-abbreviation) | Easy | String / Parsing |
+| 27 | [Lowest Common Ancestor of a Binary Tree III](https://leetcode.com/problems/lowest-common-ancestor-of-a-binary-tree-iii) | Medium | Tree / Hash Table |
+| 28 | [Convert BST to Sorted Doubly Linked List](https://leetcode.com/problems/convert-binary-search-tree-to-sorted-doubly-linked-list) | Medium | Tree / Linked List |
+| 29 | [K Closest Points to Origin](https://leetcode.com/problems/k-closest-points-to-origin) | Medium | Heap / Math |
+| 30 | [Interval List Intersections](https://leetcode.com/problems/interval-list-intersections) | Medium | Two Pointers / Intervals |
+| 31 | [Simplify Path](https://leetcode.com/problems/simplify-path) | Medium | Stack / String |
+| 32 | [Insert Delete GetRandom O(1)](https://leetcode.com/problems/insert-delete-getrandom-o1) | Medium | Design / Hash Table |
+| 33 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum) | Hard | Monotonic Deque |
+| 34 | [Regular Expression Matching](https://leetcode.com/problems/regular-expression-matching) | Hard | DP / Recursion |
+| 35 | [All Nodes Distance K in Binary Tree](https://leetcode.com/problems/all-nodes-distance-k-in-binary-tree) | Medium | Tree / BFS |
 
 </details>
 
 ## Amazon
 
 <details>
-<summary>View 25 Problems (2025-2026 Most Frequent)</summary>
+<summary>View 33 Problems (2025-2026 Most Frequent)</summary>
 
 | No. | Problem | Difficulty | Category |
 | --- | ------- | ---------- | -------- |
@@ -220,6 +244,14 @@
 | 23 | [Decode String](https://leetcode.com/problems/decode-string) | Medium | Stack / Strings |
 | 24 | [Koko Eating Bananas](https://leetcode.com/problems/koko-eating-bananas) | Medium | Binary Search |
 | 25 | [Largest Rectangle in Histogram](https://leetcode.com/problems/largest-rectangle-in-histogram) | Hard | Monotonic Stack |
+| 26 | [Car Pooling](https://leetcode.com/problems/car-pooling) | Medium | Array / Prefix Sum |
+| 27 | [Meeting Rooms III](https://leetcode.com/problems/meeting-rooms-iii) | Hard | Heap / Sorting |
+| 28 | [K Closest Points to Origin](https://leetcode.com/problems/k-closest-points-to-origin) | Medium | Heap / Math |
+| 29 | [Valid Parentheses](https://leetcode.com/problems/valid-parentheses) | Easy | Stack / String |
+| 30 | [Word Search](https://leetcode.com/problems/word-search) | Medium | Backtracking / Matrix |
+| 31 | [Course Schedule II](https://leetcode.com/problems/course-schedule-ii) | Medium | Graph / Topological Sort |
+| 32 | [Design Hit Counter](https://leetcode.com/problems/design-hit-counter) | Medium | Design / Queue |
+| 33 | [Min Stack](https://leetcode.com/problems/min-stack) | Medium | Stack / Design |
 
 </details>
 
@@ -491,6 +523,139 @@ Databricks has a unique **dedicated concurrency/multithreading round** (1 hour).
 
 </details>
 
+## Stripe
+
+<details>
+<summary>View 15 Problems + Unique Interview Format (2025-2026)</summary>
+
+Stripe does NOT use traditional LeetCode-style interviews. Problems model real engineering work -- payment processing, debugging, API integration. Code quality valued over algorithmic cleverness. Unique rounds: **Bug Squash** (debug a GitHub repo), **Integration** (build with Stripe API), **API Design** (REST resource modeling).
+
+**LeetCode-Mapped Practice Problems**
+
+| No. | Problem | Difficulty | Category |
+| --- | ------- | ---------- | -------- |
+| 1 | [Two Sum](https://leetcode.com/problems/two-sum) | Easy | Hash Map (transaction matching) |
+| 2 | [LRU Cache](https://leetcode.com/problems/lru-cache) | Medium | Design (caching patterns) |
+| 3 | [Merge Intervals](https://leetcode.com/problems/merge-intervals) | Medium | Intervals (batch scheduling) |
+| 4 | [Design Hit Counter](https://leetcode.com/problems/design-hit-counter) | Medium | Design (rate limiting) |
+| 5 | [Top K Frequent Elements](https://leetcode.com/problems/top-k-frequent-elements) | Medium | Heap (merchant ranking) |
+| 6 | [Subarray Sum Equals K](https://leetcode.com/problems/subarray-sum-equals-k) | Medium | Prefix Sum (revenue calc) |
+| 7 | [Time Based Key-Value Store](https://leetcode.com/problems/time-based-key-value-store) | Medium | Design / Binary Search |
+| 8 | [Course Schedule](https://leetcode.com/problems/course-schedule) | Medium | Graph / Cycle Detection |
+| 9 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum) | Hard | Deque (event log analysis) |
+| 10 | [Serialize and Deserialize Binary Tree](https://leetcode.com/problems/serialize-and-deserialize-binary-tree) | Hard | Design (JSON parsing) |
+| 11 | [Coin Change](https://leetcode.com/problems/coin-change) | Medium | DP (fee calculation) |
+| 12 | [Group Anagrams](https://leetcode.com/problems/group-anagrams) | Medium | Hashing / Strings |
+| 13 | [Product of Array Except Self](https://leetcode.com/problems/product-of-array-except-self) | Medium | Arrays / Prefix |
+| 14 | [Longest Substring Without Repeating Characters](https://leetcode.com/problems/longest-substring-without-repeating-characters) | Medium | Sliding Window |
+| 15 | [Number of Islands](https://leetcode.com/problems/number-of-islands) | Medium | Graph / DFS |
+
+**Custom Problems**: Invoice reconciliation (CSV parsing), request deduplication (idempotency), webhook handler debugging, payment retry logic with exponential backoff, shipping cost calculator with progressive complexity
+
+</details>
+
+## NVIDIA
+
+<details>
+<summary>View 20 Problems (2025-2026 -- GPU/Performance Focus)</summary>
+
+NVIDIA interviews emphasize performance awareness (cache hierarchies, memory bandwidth, parallelization). After solving the baseline, expect: "How does this behave under memory pressure? How would you parallelize across 10,000 threads?" C++ essential for systems/GPU roles.
+
+| No. | Problem | Difficulty | Category |
+| --- | ------- | ---------- | -------- |
+| 1 | [Maximum Number of Events That Can Be Attended](https://leetcode.com/problems/maximum-number-of-events-that-can-be-attended) | Medium | Greedy / Heap |
+| 2 | [Min Stack](https://leetcode.com/problems/min-stack) | Medium | Stack / Design |
+| 3 | [Clone Graph](https://leetcode.com/problems/clone-graph) | Medium | Graph / DFS |
+| 4 | [K Closest Points to Origin](https://leetcode.com/problems/k-closest-points-to-origin) | Medium | Heap / Math |
+| 5 | [Random Pick with Weight](https://leetcode.com/problems/random-pick-with-weight) | Medium | Binary Search / Prefix Sum |
+| 6 | [Trapping Rain Water](https://leetcode.com/problems/trapping-rain-water) | Hard | Two Pointers / Stack |
+| 7 | [Number of Islands](https://leetcode.com/problems/number-of-islands) | Medium | Graph / DFS / BFS |
+| 8 | [Rotate Image](https://leetcode.com/problems/rotate-image) | Medium | Array / Matrix |
+| 9 | [Word Break](https://leetcode.com/problems/word-break) | Medium | Dynamic Programming |
+| 10 | [Shortest Path in Binary Matrix](https://leetcode.com/problems/shortest-path-in-binary-matrix) | Medium | BFS / Graph |
+| 11 | [Design HashMap](https://leetcode.com/problems/design-hashmap) | Easy | Design / Hash Table |
+| 12 | [Longest Increasing Path in a Matrix](https://leetcode.com/problems/longest-increasing-path-in-a-matrix) | Hard | DFS / DP / Topological Sort |
+| 13 | [Permutation in String](https://leetcode.com/problems/permutation-in-string) | Medium | Sliding Window |
+| 14 | [Expression Add Operators](https://leetcode.com/problems/expression-add-operators) | Hard | Backtracking / Math |
+| 15 | [Binary Search Tree Iterator](https://leetcode.com/problems/binary-search-tree-iterator) | Medium | Tree / Stack |
+| 16 | [Word Ladder II](https://leetcode.com/problems/word-ladder-ii) | Hard | BFS / DFS / Backtracking |
+| 17 | [Bus Routes](https://leetcode.com/problems/bus-routes) | Hard | BFS / Graph |
+| 18 | [Making A Large Island](https://leetcode.com/problems/making-a-large-island) | Hard | DFS / Union Find |
+| 19 | [Line Reflection](https://leetcode.com/problems/line-reflection) | Medium | Hash Table / Math |
+| 20 | [Missing Ranges](https://leetcode.com/problems/missing-ranges) | Easy | Array / String |
+
+**CUDA/GPU-Specific**: Matrix multiplication optimization (GEMM), CUDA kernel fusion, memory coalescing analysis, thread synchronization across blocks, multi-GPU communication patterns
+
+</details>
+
+## Uber
+
+<details>
+<summary>View 20 Problems (2025-2026 -- Domain-Driven)</summary>
+
+Uber interviews reflect the product domain -- routing, dispatch, surge pricing map to graph traversal, streaming aggregation, and sliding-window patterns. Code readability is explicitly evaluated.
+
+| No. | Problem | Difficulty | Category |
+| --- | ------- | ---------- | -------- |
+| 1 | [Maximize Amount After Two Days of Conversions](https://leetcode.com/problems/maximize-amount-after-two-days-of-conversions) | Medium | Graph / BFS |
+| 2 | [Bus Routes](https://leetcode.com/problems/bus-routes) | Hard | Graph / BFS |
+| 3 | [Alien Dictionary](https://leetcode.com/problems/alien-dictionary) | Hard | Topological Sort |
+| 4 | [Number of Islands II](https://leetcode.com/problems/number-of-islands-ii) | Hard | Union Find |
+| 5 | [Design Hit Counter](https://leetcode.com/problems/design-hit-counter) | Medium | Design / Sliding Window |
+| 6 | [Number of Islands](https://leetcode.com/problems/number-of-islands) | Medium | Graph / DFS |
+| 7 | [Spiral Matrix](https://leetcode.com/problems/spiral-matrix) | Medium | Matrix / Array |
+| 8 | [Word Search](https://leetcode.com/problems/word-search) | Medium | Backtracking / DFS |
+| 9 | [LRU Cache](https://leetcode.com/problems/lru-cache) | Medium | Design / HashMap + Linked List |
+| 10 | [Top K Frequent Elements](https://leetcode.com/problems/top-k-frequent-elements) | Medium | Heap / Bucket Sort |
+| 11 | [Evaluate Division](https://leetcode.com/problems/evaluate-division) | Medium | Graph / Weighted |
+| 12 | [Construct Quad Tree](https://leetcode.com/problems/construct-quad-tree) | Medium | Divide and Conquer |
+| 13 | [Random Pick with Weight](https://leetcode.com/problems/random-pick-with-weight) | Medium | Prefix Sum / Binary Search |
+| 14 | [Find Median from Data Stream](https://leetcode.com/problems/find-median-from-data-stream) | Hard | Two Heaps / Design |
+| 15 | [Merge Intervals](https://leetcode.com/problems/merge-intervals) | Medium | Sorting / Greedy |
+| 16 | [Meeting Rooms II](https://leetcode.com/problems/meeting-rooms-ii) | Medium | Heap / Intervals |
+| 17 | [Course Schedule](https://leetcode.com/problems/course-schedule) | Medium | Graph / Cycle Detection |
+| 18 | [Course Schedule II](https://leetcode.com/problems/course-schedule-ii) | Medium | Graph / Topological Sort |
+| 19 | [Longest Subarray With Absolute Diff <= Limit](https://leetcode.com/problems/longest-continuous-subarray-with-absolute-diff-less-than-or-equal-to-limit) | Medium | Sliding Window / Monotonic Deque |
+| 20 | [Squares of a Sorted Array](https://leetcode.com/problems/squares-of-a-sorted-array) | Easy | Two Pointers |
+
+**Custom Problems**: Expiry counter (TTL-based sessions), driver-rider matching engine, surge pricing calculator (real-time supply/demand), adaptive bitrate selector
+
+</details>
+
+## ByteDance / TikTok
+
+<details>
+<summary>View 20 Problems (2025-2026 -- High Difficulty)</summary>
+
+ByteDance interviews are among the most technically demanding in the industry. Baseline is Medium, Hard is frequent. Candidates solve 2-3 problems per round (vs 1-2 at Google/Meta). Interviewers progressively modify problems to increase difficulty in real-time. Compile-ready, bug-free code expected.
+
+| No. | Problem | Difficulty | Category |
+| --- | ------- | ---------- | -------- |
+| 1 | [Implement Queue using Stacks](https://leetcode.com/problems/implement-queue-using-stacks) | Easy | Stack / Queue / Design |
+| 2 | [Daily Temperatures](https://leetcode.com/problems/daily-temperatures) | Medium | Monotonic Stack |
+| 3 | [Merge k Sorted Lists](https://leetcode.com/problems/merge-k-sorted-lists) | Hard | Linked List / Heap |
+| 4 | [LRU Cache](https://leetcode.com/problems/lru-cache) | Medium | Design / Hash + Linked List |
+| 5 | [Max Consecutive Ones III](https://leetcode.com/problems/max-consecutive-ones-iii) | Medium | Sliding Window |
+| 6 | [Sliding Window Maximum](https://leetcode.com/problems/sliding-window-maximum) | Hard | Deque / Sliding Window |
+| 7 | [Number of Islands](https://leetcode.com/problems/number-of-islands) | Medium | Graph / DFS / BFS |
+| 8 | [Search in Rotated Sorted Array](https://leetcode.com/problems/search-in-rotated-sorted-array) | Medium | Binary Search |
+| 9 | [Binary Tree Maximum Path Sum](https://leetcode.com/problems/binary-tree-maximum-path-sum) | Hard | Tree / DFS |
+| 10 | [Trapping Rain Water](https://leetcode.com/problems/trapping-rain-water) | Hard | Two Pointers / DP |
+| 11 | [Course Schedule II](https://leetcode.com/problems/course-schedule-ii) | Medium | Graph / Topological Sort |
+| 12 | [3Sum](https://leetcode.com/problems/3sum) | Medium | Two Pointers / Array |
+| 13 | [Longest Valid Parentheses](https://leetcode.com/problems/longest-valid-parentheses) | Hard | Stack / DP |
+| 14 | [N-Queens](https://leetcode.com/problems/n-queens) | Hard | Backtracking |
+| 15 | [Serialize and Deserialize Binary Tree](https://leetcode.com/problems/serialize-and-deserialize-binary-tree) | Hard | Tree / Design |
+| 16 | [Kth Largest Element in an Array](https://leetcode.com/problems/kth-largest-element-in-an-array) | Medium | Heap / Quickselect |
+| 17 | [Coin Change](https://leetcode.com/problems/coin-change) | Medium | Dynamic Programming |
+| 18 | [Regular Expression Matching](https://leetcode.com/problems/regular-expression-matching) | Hard | DP / String |
+| 19 | [Longest Increasing Path in a Matrix](https://leetcode.com/problems/longest-increasing-path-in-a-matrix) | Hard | DFS / DP / Topological Sort |
+| 20 | [Minimum Difference in Sums After Removal of Elements](https://leetcode.com/problems/minimum-difference-in-sums-after-removal-of-elements) | Hard | Heap / Greedy |
+
+**Custom Problems**: Video chunk scheduler, hashtag trend detector (sliding window on streams), comment tree flattening, content moderation priority queue, video deduplication via hashing
+
+</details>
+
 ## Flipkart
 
 <details>
@@ -506,7 +671,7 @@ Databricks has a unique **dedicated concurrency/multithreading round** (1 hour).
 
 ## About This Repository
 
-This repository covers 500+ coding problems across 13+ companies, organized by company and topic. Includes NeetCode 150, Blind 75, system design guides, and ML/AI interview resources.
+This repository covers 600+ coding problems across 17+ companies, organized by company and topic. Includes NeetCode 150, Blind 75, system design guides, and ML/AI interview resources.
 
 **[Complete System Design Interview Guide](SYSTEM_DESIGN_INTERVIEW.md)** - 25 system design problems with complexity ratings and company tags.
 

--- a/SYSTEM_DESIGN_INTERVIEW.md
+++ b/SYSTEM_DESIGN_INTERVIEW.md
@@ -36,9 +36,9 @@ This table presents 25 essential system design problems that are frequently aske
 | 24 | Design a Real-time Collaboration Editor (like Google Docs) | High | Google, Microsoft, Notion, Coda | SWE, Frontend, Real-time | [Google Research](https://research.google/pubs/pub44830/), [System Design Interview Vol 2](https://www.amazon.com/System-Design-Interview-Insiders-Guide/dp/1736049119) |
 | 25 | Design a Stock Trading System | High | Robinhood, Intuit, Citadel, JPMorgan | SWE, Financial, Real-time | [Robinhood Engineering Blog](https://robinhood.engineering/), [System Design Interview Vol 1](https://www.amazon.com/System-Design-Interview-insiders-Second/dp/B08CMF2CQF) |
 
-## Latest System Design Questions for 2025
+## Latest System Design Questions for 2025-2026
 
-The system design landscape is rapidly evolving with new technologies and architectural patterns. Here are the most recent system design problems being asked in 2025 interviews at top tech companies:
+The system design landscape is rapidly evolving with new technologies and architectural patterns. Here are the most recent system design problems being asked in 2025-2026 interviews at top tech companies:
 
 | # | Problem | Complexity | Companies | Roles | Key Considerations |
 |---|---------|------------|-----------|-------|-------------------|
@@ -53,9 +53,26 @@ The system design landscape is rapidly evolving with new technologies and archit
 | 9 | Design a Low-latency Global ML Inference System | High | OpenAI, Google, Anthropic, Meta | ML Infra, Cloud | Load balancing, model serving, region optimization, model quantization |
 | 10 | Design a Quantum Computing Interface | Very High | IBM, Google, Microsoft, Amazon | Quantum, Cloud | Quantum-classical integration, error correction, abstraction layers |
 
-### Emerging System Design Trends in 2025
+### AI-Native System Design Questions (New in 2026)
 
-Several key trends are shaping system design interviews in 2025:
+These questions reflect the shift toward AI-native architectures in 2026 interviews:
+
+| # | Problem | Complexity | Companies | Key Considerations |
+|---|---------|------------|-----------|-------------------|
+| 1 | Design a Hallucination-Free Banking Chatbot | High | Stripe, JPMorgan, Google | Domain-constrained generation, citation verification, regulatory compliance |
+| 2 | Design a Perplexity.ai / LLM-Powered Search Engine | Very High | Google, OpenAI, Anthropic | RAG + live web crawling, citation generation, streaming responses |
+| 3 | Design an AI Co-pilot like GitHub Copilot | High | Microsoft, Google, JetBrains | Context management across files, latency-sensitive completion, model routing |
+| 4 | Design an Image Generation Service (Midjourney/DALL-E) | High | OpenAI, Google, Meta | Queue management, GPU scheduling, content safety filtering at scale |
+| 5 | Design a Feature Store for ML Models | High | Netflix, Uber, Airbnb | Batch vs real-time features, training-serving skew, feature versioning |
+| 6 | Design Real-Time Fraud Detection System | High | Stripe, PayPal, Amazon | 50ms latency at 50K TPS, continuous model updates, feature engineering |
+| 7 | Design ML Model Monitoring in Production | Medium | All | Drift detection (data, concept, prediction), automated alerting, degradation response |
+| 8 | Design an Autonomous AI Travel Booking Agent | High | OpenAI, Anthropic, Google | Orchestrator + tool gateway, credential management, rollback, risk-classified actions |
+| 9 | Design a Hospital Voice Assistant | Very High | Google, Amazon, Apple | Multimodal (STT + LLM + TTS), HIPAA compliance, medical-context latency |
+| 10 | Design a Conversational Recommender System | High | Netflix, Amazon, TikTok | Dialogue state tracking + recommendation engines |
+
+### Emerging System Design Trends in 2025-2026
+
+Several key trends are shaping system design interviews in 2025-2026:
 
 1. **AI Integration at Scale**
    - Systems now commonly incorporate AI/ML components
@@ -63,11 +80,12 @@ Several key trends are shaping system design interviews in 2025:
    - Managing prompt engineering and context at scale
    - Robust handling of AI hallucinations and errors
 
-2. **Multi-Agent Architectures**
-   - Systems with multiple specialized AI agents working together
-   - Orchestration and coordination mechanisms
-   - Conflict resolution between agents
-   - Safety guarantees and monitoring
+2. **Multi-Agent and Agentic Architectures (Major 2026 Shift)**
+   - Now a distinct interview category at senior/staff levels (Gartner: 60%+ enterprise AI apps will include agentic components by 2026)
+   - Key components: orchestrator (observe-think-act loop), tool gateway with OpenAPI schemas, memory systems (working/episodic/semantic/procedural), policy/guardrails engine
+   - Action risk classification: read-only, reversible-write, irreversible-write, external-communication
+   - Tool gateway architecture: standardized schemas, credential management via secrets managers, sandboxed execution, distributed tracing
+   - Model Context Protocol (MCP): Anthropic's open standard (Linux Foundation, co-founded with OpenAI and Block) for LLM-to-tool connections
 
 3. **Edge-Cloud Hybrid Systems**
    - Processing sensitive data at the edge


### PR DESCRIPTION
- Add Stripe, NVIDIA, Uber, ByteDance/TikTok as new company sections
- Expand Google, Meta, Amazon, Microsoft with 8-10 new problems each
- Add new OpenAI custom problems (GPU Credit Manager, SQL Engine, etc.)
- Add new Anthropic custom problems (Bank System, Package Manager, etc.)
- Update interview format trends: Meta/Google AI-enabled coding rounds, Anthropic values/culture round, LinkedIn AI-paired coding
- Add 10 AI-native system design questions (Perplexity, Copilot, etc.)
- Add agentic AI architecture patterns to system design guide
- Add 15 new LLM/AI engineering interview questions (DPO, KV cache, model tiering, advanced RAG, prompt injection, cost optimization)
- Add new 2026 interview format descriptions (AI-paired coding, reasoning labs, ethics rounds)
- Research sourced from 150+ web sources across all companies