### PR TITLE
Fix 4 dead neptune.ai answer links in ML interview prep

### DIFF
--- a/ML_INTERVIEW_PREP.md
+++ b/ML_INTERVIEW_PREP.md
@@ -23,7 +23,7 @@ A comprehensive collection of machine learning interview questions with detailed
 | Explain the bias-variance tradeoff. | [Answer](https://machinelearningmastery.com/gentle-introduction-to-the-bias-variance-trade-off-in-machine-learning/) | Medium |
 | What is overfitting and how do you combat it? | [Answer](https://elitedatascience.com/overfitting-in-machine-learning) | Easy |
 | Compare L1 and L2 regularization. | [Answer](https://www.analyticsvidhya.com/blog/2016/01/complete-tutorial-ridge-lasso-regression-python/) | Medium |
-| Explain precision, recall, F1-score, and ROC-AUC. | [Answer](https://neptune.ai/blog/f1-score-accuracy-roc-auc-pr-auc) | Medium |
+| Explain precision, recall, F1-score, and ROC-AUC. | [Answer](https://www.bestaiweb.ai/f1-score-in-production-how-medical-ai-content-moderation-and-fraud-detection-choose-their-metrics-in-2026/) | Medium |
 | What is cross-validation and why is it important? | [Answer](https://towardsdatascience.com/cross-validation-in-machine-learning-72924a69872f) | Easy |
 | Explain the difference between bagging and boosting. | [Answer](https://quantdare.com/what-is-the-difference-between-bagging-and-boosting/) | Medium |
 | How do decision trees work? Explain Random Forests and Gradient Boosting. | [Answer](https://towardsdatascience.com/decision-trees-and-random-forests-df0c3123f991) | Medium |
@@ -94,15 +94,15 @@ A comprehensive collection of machine learning interview questions with detailed
 
 | Question | Answer Link | Difficulty |
 |----------|-------------|------------|
-| What is MLOps? | [Answer](https://neptune.ai/blog/mlops) | Easy |
+| What is MLOps? | [Answer](https://www.bestaiweb.ai/glossary/mlops/) | Easy |
 | How would you deploy a machine learning model to production? | [Answer](https://www.kdnuggets.com/2019/06/approaches-deploy-machine-learning-production.html) | Medium |
 | Explain the concept of model serving. | [Answer](https://www.datacamp.com/community/blog/machine-learning-model-serving) | Medium |
 | What are the considerations for monitoring ML models in production? | [Answer](https://christophergs.github.io/machine%20learning/2020/03/14/how-to-monitor-machine-learning-models/) | Medium |
 | How do you handle model drift/decay? | [Answer](https://towardsdatascience.com/machine-learning-model-drift-9cc10fa1e9a4) | Medium |
 | What is a feature store and why is it important? | [Answer](https://www.tecton.ai/blog/what-is-a-feature-store/) | Medium |
-| How would you version control ML models? | [Answer](https://neptune.ai/blog/ml-model-versioning) | Medium |
+| How would you version control ML models? | [Answer](https://web.archive.org/web/20251006160752/https://neptune.ai/blog/version-control-for-ml-models) | Medium |
 | What is containerization and how is it useful for ML deployment? | [Answer](https://www.oreilly.com/content/containerized-machine-learning/) | Medium |
-| Explain CI/CD in the context of ML systems. | [Answer](https://neptune.ai/blog/ci-cd-for-machine-learning-mlops) | Medium |
+| Explain CI/CD in the context of ML systems. | [Answer](https://web.archive.org/web/20231201134807/https://neptune.ai/blog/continuous-integration-continuous-deployment-tools-for-machine-learning) | Medium |
 | What are the ethical considerations in deploying ML models? | [Answer](https://towardsdatascience.com/ethics-in-machine-learning-9fa5b1aadc12) | Medium |
 
 ## ML System Design Questions and Strategies


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now redirects to the acquisition announcement, so the neptune.ai/blog links in this repo no longer lead to the referenced articles.

This PR fixes the 4 dead *Answer* links in `ML_INTERVIEW_PREP.md`:

- **F1/ROC-AUC metrics** and **What is MLOps** → live articles on bestaiweb.ai covering the same questions
- **ML model versioning** and **CI/CD for ML** → Wayback Machine snapshots. Note: the two original URLs (`ml-model-versioning`, `ci-cd-for-machine-learning-mlops`) appear to have never resolved — no archived capture of them exists — so I pointed these to the archived copies of Neptune's closest real articles on those topics.

**Disclosure:** I'm one of the authors of bestaiweb.ai. I've only used our pages where they genuinely cover the same ground as the dead article; the remaining fixes point to the Internet Archive (pinned to the last capture before the redirect). Happy to switch any of these to archive.org snapshots instead if you prefer.